### PR TITLE
[opt] add cache and modify api

### DIFF
--- a/examples/opt/cache.py
+++ b/examples/opt/cache.py
@@ -1,0 +1,64 @@
+from collections import OrderedDict
+from threading import Lock
+from contextlib import contextmanager
+from typing import List, Any, Hashable, Dict
+
+
+class MissCacheError(Exception):
+    pass
+
+
+class ListCache:
+    def __init__(self, cache_size: int, list_size: int, fixed_keys: List[Hashable] = []) -> None:
+        """Cache a list of values. The fixed keys won't be removed. For other keys, LRU is applied.
+        When the value list is not full, a cache miss occurs. Otherwise, a cache hit occurs. Redundant values will be removed.
+
+        Args:
+            cache_size (int): Max size for LRU cache.
+            list_size (int): Value list size.
+            fixed_keys (List[Hashable], optional): The keys which won't be removed. Defaults to [].
+        """
+        self.cache_size = cache_size
+        self.list_size = list_size
+        self.cache: OrderedDict[Hashable, List[Any]] = OrderedDict()
+        self.fixed_cache: Dict[Hashable, List[Any]] = {}
+        for key in fixed_keys:
+            self.fixed_cache[key] = []
+        self._lock = Lock()
+
+    def get(self, key: Hashable) -> List[Any]:
+        with self.lock():
+            if key in self.fixed_cache:
+                l = self.fixed_cache[key]
+                if len(l) >= self.list_size:
+                    return l
+            elif key in self.cache:
+                self.cache.move_to_end(key)
+                l = self.cache[key]
+                if len(l) >= self.list_size:
+                    return l
+        raise MissCacheError()
+
+    def add(self, key: Hashable, value: Any) -> None:
+        with self.lock():
+            if key in self.fixed_cache:
+                l = self.fixed_cache[key]
+                if len(l) < self.list_size and value not in l:
+                    l.append(value)
+            elif key in self.cache:
+                self.cache.move_to_end(key)
+                l = self.cache[key]
+                if len(l) < self.list_size and value not in l:
+                    l.append(value)
+            else:
+                if len(self.cache) >= self.cache_size:
+                    self.cache.popitem(last=False)
+                self.cache[key] = [value]
+
+    @contextmanager
+    def lock(self):
+        try:
+            self._lock.acquire()
+            yield
+        finally:
+            self._lock.release()

--- a/examples/opt/executor.py
+++ b/examples/opt/executor.py
@@ -64,8 +64,7 @@ class Executor:
         if not self.running:
             raise RuntimeError('executor is shutdown')
         args = GenerationArgs(top_k, top_p, temperature)
-        decode_steps = max_tokens - len(inputs['input_ids'])
-        entry = SubmitEntry(inputs, args, decode_steps)
+        entry = SubmitEntry(inputs, args, max_tokens)
         self.submit_queue.append(entry)
         return id(entry)
 

--- a/examples/opt/opt_config.py
+++ b/examples/opt/opt_config.py
@@ -25,3 +25,7 @@ tokenizer_path = "facebook/opt-350m"
 server_host = "0.0.0.0"
 server_port = 8020
 log_level = "info"
+allow_cors = True
+executor_max_batch_size = 16
+cache_size = 50
+cache_list_size = 2


### PR DESCRIPTION
## Add cache
For example, `ListCache(50, 2, fixed_keys=fixed_cache_keys)` will cache 50 keys (except fixed keys). Each key is linked to 2 different values. LRU is applied when cache is full. The fixed keys are always in cache and won't be removed.

## Modify api
`"max_tokens"` in request is the same as the number of decode steps now.