### PR TITLE
[opt] add opt-6.7b and add fastapi server

### DIFF
--- a/energonai/model/__init__.py
+++ b/energonai/model/__init__.py
@@ -1,4 +1,4 @@
 from .model_factory import gpt2_small, gpt2_large, gpt2_8B, gpt3
 from .model_factory import hf_gpt2
 from .model_factory import bert_small, bert_large, bert_8B, bert_175B
-from .model_factory import opt_125M, opt_30B, opt_66B, opt_175B
+from .model_factory import opt_125M, opt_6B, opt_30B, opt_66B, opt_175B

--- a/energonai/model/model_factory.py
+++ b/energonai/model/model_factory.py
@@ -283,6 +283,21 @@ def opt_125M(**kwargs):
     return create_pipeline_model(**model_kwargs)
 
 
+def opt_6B(**kwargs):
+    model_kwargs = dict(vocab_size=50272,
+                        hidden_size=4096,
+                        depth=32,
+                        max_seq_len=2050,
+                        num_heads=32,
+                        activation=nn.functional.relu,
+                        is_decoder=True,
+                        fused_qkv=False,
+                        model_name="opt",
+                        disable_past_cache=False,
+                        **kwargs)
+    return create_pipeline_model(**model_kwargs)
+
+
 def opt_30B(**kwargs):
     model_kwargs = dict(vocab_size=50272,
                         hidden_size=7168,

--- a/energonai/utils/checkpointing_opt.py
+++ b/energonai/utils/checkpointing_opt.py
@@ -42,6 +42,8 @@ def module_name_mapping(ori_name: str):
         return "embed.position_embeddings.weight"
     elif "decoder.layer_norm" in ori_name:
         return ori_name.replace('decoder.layer_norm', 'norm')
+    elif "decoder.final_layer_norm" in ori_name:  # hugging face style
+        return ori_name.replace('decoder.final_layer_norm', 'norm')
     # elif ".attn.bias" in ori_name:
     #     return ""
     else:
@@ -94,7 +96,8 @@ def processing_OPT(state_dict: OrderedDict):
     if 'head.dense.weight' not in new_dict:
         new_dict['head.dense.weight'] = new_dict['embed.word_embeddings.weight'].clone()
 
-    del new_dict['decoder.version']
+    if 'decoder.version' in new_dict:
+        del new_dict['decoder.version']
     # print("="*100)
     # print(new_dict.keys())
     # print("---------------------------")

--- a/examples/opt/README.md
+++ b/examples/opt/README.md
@@ -1,0 +1,67 @@
+# Overview
+
+This is an example showing how to run OPT generation. The OPT model is implemented using ColossalAI.
+
+It supports tensor parallelism, batching and caching.
+
+# How to run
+
+Run OPT-125M:
+```shell
+python opt_fastapi.py opt-125m
+```
+
+## Configure
+
+### Configure model:
+```shell
+python opt_fastapi.py <model>
+```
+Available models: opt-125m, opt-6.7b, opt-30b, opt-175b.
+
+### Configure tensor parallelism
+```shell
+python opt_fastapi.py <model> --tp <TensorParallelismWorldSize>
+```
+The `<TensorParallelismWorldSize>` can be an integer in `[1, #GPUs]`. Default `1`.
+
+### Configure checkpoint
+```shell
+python opt_fastapi.py <model> --checkpoint <CheckpointPath>
+```
+The `<CheckpointPath>` can be a file path or a directory path. If it's a directory path, all files under the directory will be loaded.
+
+### Configure queue
+```shell
+python opt_fastapi.py <model> --queue_size <QueueSize>
+```
+The `<QueueSize>` can be an integer in `[0, MAXINT]`. If it's `0`, the request queue size is infinite. If it's a positive integer, when the request queue is full, incoming requests will be dropped (the HTTP status code of response will be 406).
+
+### Configure bathcing
+```shell
+python opt_fastapi.py <model> --max_batch_size <MaxBatchSize>
+```
+The `<MaxBatchSize>` can be an integer in `[1, MAXINT]`. The engine will make batch whose size is less or equal to this value.
+
+Note that the batch size is not always equal to `<MaxBatchSize>`, as some consecutive requests may not be batched.
+
+### Configure caching
+```shell
+python opt_fastapi.py <model> --cache_size <CacheSize> --cache_list_size <CacheListSize>
+```
+This will cache `<CacheSize>` unique requests. And for each unique request, it cache `<CacheListSize>` different results. A random result will be returned if the cache is hit.
+
+The `<CacheSize>` can be an integer in `[0, MAXINT]`. If it's `0`, cache won't be applied. The `<CacheListSize>` can be an integer in `[1, MAXINT]`.
+
+### Other configurations
+```shell
+python opt_fastapi.py -h
+```
+
+# How to benchmark
+```shell
+cd benchmark
+locust
+```
+
+Then open the web interface link which is on your console.

--- a/examples/opt/README.md
+++ b/examples/opt/README.md
@@ -13,7 +13,7 @@ python opt_fastapi.py opt-125m
 
 ## Configure
 
-### Configure model:
+### Configure model
 ```shell
 python opt_fastapi.py <model>
 ```

--- a/examples/opt/opt_fastapi.py
+++ b/examples/opt/opt_fastapi.py
@@ -1,15 +1,17 @@
-import logging
 import argparse
+import logging
 import random
-import uvicorn
-from pydantic import BaseModel, Field
 from typing import Optional
-from energonai.model import opt_125M, opt_30B, opt_175B
+
+import uvicorn
+from energonai import QueueFullError, launch_engine
+from energonai.model import opt_6B, opt_30B, opt_125M, opt_175B
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel, Field
 from transformers import GPT2Tokenizer
-from energonai import launch_engine, QueueFullError
+
 from batch import BatchManagerForGeneration
 from cache import ListCache, MissCacheError
-from fastapi import FastAPI, Request, HTTPException
 
 
 class GenerationTaskReq(BaseModel):
@@ -64,6 +66,7 @@ async def shutdown(*_):
 def get_model_fn(model_name: str):
     model_map = {
         'opt-125m': opt_125M,
+        'opt-6.7b': opt_6B,
         'opt-30b': opt_30B,
         'opt-175b': opt_175B
     }
@@ -84,7 +87,7 @@ FIXED_CACHE_KEYS = [
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('model', choices=['opt-125m', 'opt-30b', 'opt-175b'])
+    parser.add_argument('model', choices=['opt-125m', 'opt-6.7b', 'opt-30b', 'opt-175b'])
     parser.add_argument('--tp', type=int, default=1)
     parser.add_argument('--master_host', default='localhost')
     parser.add_argument('--master_port', type=int, default=19990)

--- a/examples/opt/requirements.txt
+++ b/examples/opt/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.85.1
+locust==2.11.0
+pydantic==1.10.2
+sanic==22.9.0
+sanic_ext==22.9.0
+torch>=1.10.0
+transformers==4.23.1
+uvicorn==0.19.0


### PR DESCRIPTION
# How to run

Run OPT-125M:
```shell
python opt_fastapi.py opt-125m
```

## Configure

### Configure model:
```shell
python opt_fastapi.py <model>
```
Available models: opt-125m, opt-6.7b, opt-30b, opt-175b.

### Configure tensor parallelism
```shell
python opt_fastapi.py <model> --tp <TensorParallelismWorldSize>
```
The `<TensorParallelismWorldSize>` can be an integer in `[1, #GPUs]`. Default `1`.

### Configure checkpoint
```shell
python opt_fastapi.py <model> --checkpoint <CheckpointPath>
```
The `<CheckpointPath>` can be a file path or a directory path. If it's a directory path, all files under the directory will be loaded.

### Configure queue
```shell
python opt_fastapi.py <model> --queue_size <QueueSize>
```
The `<QueueSize>` can be an integer in `[0, MAXINT]`. If it's `0`, the request queue size is infinite. If it's a positive integer, when the request queue is full, incoming requests will be dropped (the HTTP status code of response will be 406).

### Configure bathcing
```shell
python opt_fastapi.py <model> --max_batch_size <MaxBatchSize>
```
The `<MaxBatchSize>` can be an integer in `[1, MAXINT]`. The engine will make batch whose size is less or equal to this value.

Note that the batch size is not always equal to `<MaxBatchSize>`, as some consecutive requests may not be batched.

### Configure caching
```shell
python opt_fastapi.py <model> --cache_size <CacheSize> --cache_list_size <CacheListSize>
```
This will cache `<CacheSize>` unique requests. And for each unique request, it cache `<CacheListSize>` different results. A random result will be returned if the cache is hit.

The `<CacheSize>` can be an integer in `[0, MAXINT]`. If it's `0`, cache won't be applied. The `<CacheListSize>` can be an integer in `[1, MAXINT]`.

### Other configurations
```shell
python opt_fastapi.py -h
```