### PR TITLE
[hotfix] fix rpc init and opt checkpoint key mapping

### DIFF
--- a/energonai/model/model_factory.py
+++ b/energonai/model/model_factory.py
@@ -1,22 +1,32 @@
 import os
-import time
-import torch
 import random
-from torch import nn, dtype
+import time
 from typing import Callable, Optional
-from .endecoder import Block1D
-from .embedding import Embedding1D
-from .downstream import LMHead1D
 
-from colossalai.nn import LayerNorm1D
-from colossalai.core import global_context as gpc
+import torch
 from colossalai.context import ParallelMode
-from colossalai.utils import is_using_pp, get_current_device
+from colossalai.core import global_context as gpc
 from colossalai.logging import get_dist_logger
+from colossalai.nn import LayerNorm1D
+from colossalai.utils import get_current_device, is_using_pp
+from torch import dtype, nn
+
 from energonai.utils.checkpointing import load_checkpoint
 from energonai.utils.checkpointing_hf_gpt2 import processing_HF_GPT
-from energonai.utils.checkpointing_opt import processing_OPT, load_175b
-from transformers.generation_logits_process import TopKLogitsWarper, TopPLogitsWarper, TemperatureLogitsWarper, LogitsProcessorList
+from energonai.utils.checkpointing_opt import load_175b, processing_OPT
+
+from .downstream import LMHead1D
+from .embedding import Embedding1D
+from .endecoder import Block1D
+
+try:
+    from transformers.generation_logits_process import (
+        LogitsProcessorList, TemperatureLogitsWarper, TopKLogitsWarper,
+        TopPLogitsWarper)
+except ImportError:
+    from transformers.generation import (LogitsProcessorList,
+                                         TemperatureLogitsWarper,
+                                         TopKLogitsWarper, TopPLogitsWarper)
 
 
 def gelu_impl(x):

--- a/energonai/utils/checkpointing_opt.py
+++ b/energonai/utils/checkpointing_opt.py
@@ -1,11 +1,11 @@
-import re
 import os
-import torch
+import re
 from collections import OrderedDict
-from colossalai.core import global_context as gpc
-from colossalai.context import ParallelMode
 from typing import Dict
 
+import torch
+from colossalai.context import ParallelMode
+from colossalai.core import global_context as gpc
 
 __all__ = [
     'processing_OPT'
@@ -19,8 +19,8 @@ name_map = {
     'self_attn.k_proj': 'attn.key_',
     'self_attn.v_proj': 'attn.value_',
     'self_attn.out_proj': 'attn.dense',
-    'self_attn_layer_norm': 'norm1',
-    'final_layer_norm': 'norm2',
+    'self_attn_layer_norm': 'norm1.module',
+    'final_layer_norm': 'norm2.module',
     'fc1': 'mlp.dense_1',
     'fc2': 'mlp.dense_2'
 }
@@ -41,9 +41,9 @@ def module_name_mapping(ori_name: str):
     elif ori_name == 'decoder.embed_positions.weight':
         return "embed.position_embeddings.weight"
     elif "decoder.layer_norm" in ori_name:
-        return ori_name.replace('decoder.layer_norm', 'norm')
+        return ori_name.replace('decoder.layer_norm', 'norm.module')
     elif "decoder.final_layer_norm" in ori_name:  # hugging face style
-        return ori_name.replace('decoder.final_layer_norm', 'norm')
+        return ori_name.replace('decoder.final_layer_norm', 'norm.module')
     # elif ".attn.bias" in ori_name:
     #     return ""
     else:

--- a/energonai/worker.py
+++ b/energonai/worker.py
@@ -1,22 +1,24 @@
-import colossalai
 import time
+from contextlib import contextmanager
+from typing import Any, Callable
+
+import colossalai
 import torch
-import torch.nn as nn
 import torch.distributed.rpc as trpc
 import torch.multiprocessing as mp
-from typing import Callable, Any
+import torch.nn as nn
 from colossalai.context import ParallelMode
 from colossalai.core import global_context as gpc
 from colossalai.logging import disable_existing_loggers, get_dist_logger
-from contextlib import contextmanager
-from .task import TaskEntry
-from .utils import build_device_maps, Terminator
+
 from .pipe import Pipe
+from .task import TaskEntry
+from .utils import Terminator, build_device_maps
 
 
 class Worker:
     def __init__(self, rank: int, tp_world_size: int, pp_world_size: int, master_host: str, master_port: int, rpc_port: int, n_proc_per_node: int,
-                 model_fn: Callable[[Any], nn.Module], pipe_size: int = 1, **model_kwargs: Any) -> None:
+                 model_fn: Callable[[Any], nn.Module], pipe_size: int = 1, rpc_disable_shm: bool = True, **model_kwargs: Any) -> None:
         self.global_rank = rank
         self.world_size = tp_world_size * pp_world_size
         self.tp_world_size = tp_world_size
@@ -30,10 +32,17 @@ class Worker:
         self.model: nn.Module = model_fn(**model_kwargs).cuda()
 
         self.rpc_name = f'worker{self.global_rank}'
+        rpc_options = {}
+        if rpc_disable_shm:
+            # SHM may lead to timeout error. Disabling SHM and only enabling uv transport can solve this problem.
+            # See https://discuss.pytorch.org/t/rpc-behavior-difference-between-pytorch-1-7-0-vs-1-9-0/124772/5
+            # This is a workaround and may be solved in the future.
+            rpc_options['_transports'] = ['uv']
         trpc.init_rpc(self.rpc_name, rank=self.global_rank + 1, world_size=self.world_size + 1,
                       rpc_backend_options=trpc.TensorPipeRpcBackendOptions(
                           init_method=f'tcp://{master_host}:{rpc_port}',
-                          device_maps=build_device_maps(self.world_size, n_proc_per_node, rank=self.global_rank)
+                          device_maps=build_device_maps(self.world_size, n_proc_per_node, rank=self.global_rank),
+                          **rpc_options
                       ))
         self.to_master_pipe = Pipe(f'{self.global_rank}_to_m', self.rpc_name, 'master')
         self.to_master_pipe.send(self.pp_rank)
@@ -89,13 +98,13 @@ class Worker:
 
 
 def launch_workers(tp_world_size: int, pp_world_size: int, master_host: str, master_port: int, rpc_port: int,
-                   model_fn: Callable[[Any], nn.Module], n_proc_per_node: int = 1, node_rank: int = 0, pipe_size: int = 1,
+                   model_fn: Callable[[Any], nn.Module], n_proc_per_node: int = 1, node_rank: int = 0, pipe_size: int = 1, rpc_disable_shm: bool = True,
                    **model_kwargs: Any) -> None:
     ctx = mp.get_context('spawn')
     procs = []
     for i in range(n_proc_per_node):
         rank = n_proc_per_node * node_rank + i
         p = ctx.Process(target=Worker, args=(rank, tp_world_size, pp_world_size,
-                                             master_host, master_port, rpc_port, n_proc_per_node, model_fn, pipe_size), kwargs=model_kwargs)
+                                             master_host, master_port, rpc_port, n_proc_per_node, model_fn, pipe_size, rpc_disable_shm), kwargs=model_kwargs)
         procs.append(p)
         p.start()


### PR DESCRIPTION
1. As discussed in https://discuss.pytorch.org/t/rpc-behavior-difference-between-pytorch-1-7-0-vs-1-9-0/124772/5, torch rpc init may get a timeout error when using SHM. We add an argument to control whether we use SHM.
2. ColossalAI's layernorm leads to wrong checkpoint key mapping. OPT-125m may fail due to this problem. Fix this key mapping.